### PR TITLE
Add sign-in button to TopNav for unauthenticated users

### DIFF
--- a/client/src/components/layout/TopNav.jsx
+++ b/client/src/components/layout/TopNav.jsx
@@ -2,8 +2,12 @@ import { Bell, Menu } from 'lucide-react';
 import ThemeToggle from '../../theme/ThemeToggle.jsx';
 import { Button } from '../ui/Button.jsx';
 import { Input } from '../ui/Input.jsx';
+import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 
 export default function TopNav({ onMenuClick }) {
+  const { currentUser } = useSelector((state) => state.user);
+
   return (
     <header className="sticky top-0 z-40 border-b bg-white/80 backdrop-blur dark:bg-gray-900/80">
       <div className="flex h-16 items-center gap-4 px-4">
@@ -23,6 +27,13 @@ export default function TopNav({ onMenuClick }) {
           <div className="hidden w-full max-w-xs md:block">
             <Input type="search" placeholder="Search..." aria-label="Search" />
           </div>
+          {!currentUser && (
+            <Link to="/sign-in">
+              <Button variant="primary" size="sm" aria-label="Sign in">
+                Sign In
+              </Button>
+            </Link>
+          )}
           <Button variant="ghost" size="sm" aria-label="Notifications">
             <Bell className="h-5 w-5" />
           </Button>


### PR DESCRIPTION
## Summary
- add conditional sign-in button to top navigation
- import routing and redux utilities for auth awareness

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c0ddc91774832d94bf9df23ede78d8