### PR TITLE
feat: add signout endpoint

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -164,3 +164,17 @@ export const github = async (req, res, next) => {
         next(error);
     }
 };
+
+export const signout = (req, res, next) => {
+    try {
+        res.clearCookie('access_token', {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'strict',
+        })
+            .status(200)
+            .json('User has been signed out');
+    } catch (error) {
+        next(error);
+    }
+};

--- a/api/routes/auth.route.js
+++ b/api/routes/auth.route.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { google, signin, signup, github } from '../controllers/auth.controller.js';
+import { google, signin, signup, github, signout } from '../controllers/auth.controller.js';
 
 const router = express.Router();
 
@@ -7,5 +7,6 @@ router.post('/signup', signup);
 router.post('/signin', signin);
 router.post('/google', google);
 router.post('/github', github);
+router.post('/signout', signout);
 
 export default router;

--- a/api/routes/auth.route.test.js
+++ b/api/routes/auth.route.test.js
@@ -61,4 +61,13 @@ describe('Auth routes', () => {
         expect(res.status).toBe(400);
         expect(res.body.message).toMatch(/required/);
     });
+
+    it('clears the access token cookie on signout', async () => {
+        const res = await request(app).post('/api/auth/signout');
+
+        expect(res.status).toBe(200);
+        expect(res.body).toBe('User has been signed out');
+        const cookies = res.get('Set-Cookie') || [];
+        expect(cookies.some((cookie) => /^access_token=;/i.test(cookie))).toBe(true);
+    });
 });


### PR DESCRIPTION
## Summary
- add dedicated signout controller to clear auth cookies
- expose signout route alongside existing auth endpoints
- verify signout clears cookie via new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c0e2db8b90832da04d6ecebdd092ce