### PR TITLE
feat: show user avatar in app shell

### DIFF
--- a/client/src/ui/AppShell.jsx
+++ b/client/src/ui/AppShell.jsx
@@ -1,8 +1,24 @@
 /* eslint-disable react/prop-types */
+import { Avatar, Dropdown } from 'flowbite-react';
+import { Link } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { signoutSuccess } from '../redux/user/userSlice';
 import ThemeToggle from './ThemeToggle';
 import Footer from '../components/Footer';
 
 export default function AppShell({ sidebar, children }) {
+  const { currentUser } = useSelector((state) => state.user);
+  const dispatch = useDispatch();
+
+  const handleSignout = async () => {
+    try {
+      await fetch('/api/user/signout', { method: 'POST' });
+      dispatch(signoutSuccess());
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
   return (
     <div className="flex min-h-screen flex-col bg-bg text-text">
       <a href="#main" className="skip-to-content">
@@ -18,6 +34,37 @@ export default function AppShell({ sidebar, children }) {
             <a href="/projects" className="hocus:underline">
               Projects
             </a>
+            {currentUser ? (
+              <Dropdown
+                inline
+                arrowIcon={false}
+                label={
+                  <Avatar
+                    img={currentUser.profilePicture}
+                    alt={currentUser.username || 'user'}
+                    rounded
+                  />
+                }
+              >
+                <Dropdown.Header>
+                  <span className="block text-sm">@{currentUser.username}</span>
+                  <span className="block truncate text-sm font-medium">
+                    {currentUser.email}
+                  </span>
+                </Dropdown.Header>
+                <Dropdown.Item as={Link} to="/dashboard?tab=profile">
+                  Profile
+                </Dropdown.Item>
+                <Dropdown.Divider />
+                <Dropdown.Item onClick={handleSignout}>
+                  Sign out
+                </Dropdown.Item>
+              </Dropdown>
+            ) : (
+              <Link to="/sign-in" className="hocus:underline">
+                Sign In
+              </Link>
+            )}
             <ThemeToggle />
           </nav>
         </div>


### PR DESCRIPTION
## Summary
- display current user avatar with dropdown navigation in `AppShell`
- include profile and sign out actions

## Testing
- `npm test`
- `npm run lint --prefix client` *(fails: 'App.jsx 2:25  error  'Outlet' is defined but never used  no-unused-vars' and many others)*
- `curl -I http://localhost:5174`
- `curl -I http://localhost:5174/dashboard?tab=profile`


------
https://chatgpt.com/codex/tasks/task_b_68c61e337084832d8f34b82456fb193a