### PR TITLE
Add AdminDashboard page with section navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -6,7 +6,7 @@ import OnlyAdminPrivateRoute from './components/OnlyAdminPrivateRoute.jsx';
 
 // Lazy-loaded page components
 const Home = lazy(() => import('./pages/Home.jsx'));
-const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
+const AdminDashboard = lazy(() => import('./pages/AdminDashboard.jsx'));
 const About = lazy(() => import('./pages/About.jsx'));
 const Projects = lazy(() => import('./pages/Projects.jsx'));
 const Tutorials = lazy(() => import('./pages/Tutorials.jsx'));
@@ -49,7 +49,7 @@ export default function App() {
                     <Route path="/visualizer" element={<CodeVisualizer />} />
 
                     <Route element={<PrivateRoute />}>
-                        <Route path="/dashboard" element={<Dashboard />} />
+                        <Route path="/dashboard" element={<AdminDashboard />} />
                         <Route element={<OnlyAdminPrivateRoute />}>
                             <Route path="/create-post" element={<CreatePost />} />
                             <Route path="/update-post/:postId" element={<UpdatePost />} />

--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import DashSidebar from '../components/DashSidebar.jsx';
+import DashPosts from '../components/DashPosts.jsx';
+import DashUsers from '../components/DashUsers.jsx';
+import DashTutorials from '../components/DashTutorials.jsx';
+import DashQuizzes from '../components/DashQuizzes.jsx';
+import DashComments from '../components/DashComments.jsx';
+import Dashboard from './Dashboard.jsx';
+
+export default function AdminDashboard() {
+  const location = useLocation();
+  const [tab, setTab] = useState('dash');
+
+  useEffect(() => {
+    const urlParams = new URLSearchParams(location.search);
+    const tabFromUrl = urlParams.get('tab');
+    if (tabFromUrl) {
+      setTab(tabFromUrl);
+    }
+  }, [location.search]);
+
+  const renderTab = () => {
+    switch (tab) {
+      case 'posts':
+        return <DashPosts />;
+      case 'users':
+        return <DashUsers />;
+      case 'tutorials':
+        return <DashTutorials />;
+      case 'quizzes':
+        return <DashQuizzes />;
+      case 'comments':
+        return <DashComments />;
+      case 'dash':
+      default:
+        return <Dashboard />;
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col md:flex-row">
+      <div className="md:w-56">
+        <DashSidebar />
+      </div>
+      <div className="flex-1 p-4">
+        {renderTab()}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create AdminDashboard page with sidebar and tabbed sections for posts, users, tutorials, quizzes, and comments
- route /dashboard to AdminDashboard component

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c629e90cd4832daf5a3754b7112fc1