### PR TITLE
Add admin dashboard route and update navigation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -49,8 +49,8 @@ export default function App() {
                     <Route path="/visualizer" element={<CodeVisualizer />} />
 
                     <Route element={<PrivateRoute />}>
-                        <Route path="/dashboard" element={<AdminDashboard />} />
                         <Route element={<OnlyAdminPrivateRoute />}>
+                            <Route path="/admin" element={<AdminDashboard />} />
                             <Route path="/create-post" element={<CreatePost />} />
                             <Route path="/update-post/:postId" element={<UpdatePost />} />
                             <Route path="/create-tutorial" element={<CreateTutorial />} />

--- a/client/src/components/CommentSection.jsx
+++ b/client/src/components/CommentSection.jsx
@@ -119,10 +119,10 @@ export default function CommentSection({ postId }) {
                   src={currentUser.profilePicture}
                   alt=''
               />
-              <Link
-                  to={'/dashboard?tab=profile'}
-                  className='text-xs text-cyan-600 hover:underline'
-              >
+                <Link
+                    to={'/admin?tab=profile'}
+                    className='text-xs text-cyan-600 hover:underline'
+                >
                 @{currentUser.username}
               </Link>
             </div>

--- a/client/src/components/DashSidebar.jsx
+++ b/client/src/components/DashSidebar.jsx
@@ -52,7 +52,7 @@ export default function DashSidebar() {
         <Sidebar.Items>
           <Sidebar.ItemGroup className='flex flex-col gap-1'>
             {/* Profile link - handled separately due to its dynamic label */}
-            <Link to='/dashboard?tab=profile'>
+              <Link to='/admin?tab=profile'>
               <Sidebar.Item
                   active={tab === 'profile'}
                   icon={HiUser}
@@ -68,7 +68,7 @@ export default function DashSidebar() {
             {sidebarLinks
                 .filter(link => currentUser.isAdmin || !link.adminOnly)
                 .map(link => (
-                    <Link to={`/dashboard?tab=${link.tab}`} key={link.tab}>
+                    <Link to={`/admin?tab=${link.tab}`} key={link.tab}>
                       <Sidebar.Item
                           active={tab === link.tab || (link.tab === 'dash' && !tab)}
                           icon={link.icon}

--- a/client/src/components/DashboardComp.jsx
+++ b/client/src/components/DashboardComp.jsx
@@ -111,9 +111,9 @@ export default function DashboardComp() {
 
         {/* Reusable Data Tables */}
         <div className='flex flex-wrap gap-4 py-3 mx-auto justify-center'>
-          <RecentDataTable
-              title='Recent users'
-              linkTo='/dashboard?tab=users'
+            <RecentDataTable
+                title='Recent users'
+                linkTo='/admin?tab=users'
               headers={['User image', 'Username']}
               data={dashboardData.users}
               renderRow={(user) => (
@@ -125,9 +125,9 @@ export default function DashboardComp() {
                   </Table.Body>
               )}
           />
-          <RecentDataTable
-              title='Recent comments'
-              linkTo='/dashboard?tab=comments'
+            <RecentDataTable
+                title='Recent comments'
+                linkTo='/admin?tab=comments'
               headers={['Comment content', 'Likes']}
               data={dashboardData.comments}
               renderRow={(comment) => (
@@ -139,9 +139,9 @@ export default function DashboardComp() {
                   </Table.Body>
               )}
           />
-          <RecentDataTable
-              title='Recent posts'
-              linkTo='/dashboard?tab=posts'
+            <RecentDataTable
+                title='Recent posts'
+                linkTo='/admin?tab=posts'
               headers={['Post image', 'Post Title', 'Category']}
               data={dashboardData.posts}
               renderRow={(post) => (

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -75,7 +75,7 @@ function CommandMenu({ isOpen, onClose }) {
     {
       section: 'Quick Actions',
       items: [
-        { label: 'Profile', path: '/dashboard?tab=profile', icon: <AiOutlineUser /> },
+          { label: 'Profile', path: '/admin?tab=profile', icon: <AiOutlineUser /> },
         { label: 'Create a Post', path: '/create-post', icon: <AiOutlineFileAdd /> },
       ],
     },
@@ -177,7 +177,7 @@ function UserProfileDropdown({ currentUser, onSignOut }) {
                     <span className='block text-xs font-medium truncate text-gray-500 dark:text-gray-400'>{currentUser.email}</span>
                   </div>
                   <div className="py-1">
-                    <Link to={'/dashboard?tab=profile'} onClick={() => setIsDropdownOpen(false)}>
+                    <Link to={'/admin?tab=profile'} onClick={() => setIsDropdownOpen(false)}>
                       <div className='flex items-center gap-3 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 cursor-pointer'>
                         <AiOutlineUser /> Profile
                       </div>

--- a/client/src/components/ProfileCompletionPrompt.jsx
+++ b/client/src/components/ProfileCompletionPrompt.jsx
@@ -27,7 +27,7 @@ export default function ProfileCompletionPrompt() {
                         <Button color="gray" onClick={() => setOpen(false)}>
                             Later
                         </Button>
-                        <Link to="/dashboard?tab=profile">
+                          <Link to="/admin?tab=profile">
                             <Button>Complete now</Button>
                         </Link>
                     </div>

--- a/client/src/ui/AppShell.jsx
+++ b/client/src/ui/AppShell.jsx
@@ -52,7 +52,7 @@ export default function AppShell({ sidebar, children }) {
                     {currentUser.email}
                   </span>
                 </Dropdown.Header>
-                <Dropdown.Item as={Link} to="/dashboard?tab=profile">
+                <Dropdown.Item as={Link} to="/admin?tab=profile">
                   Profile
                 </Dropdown.Item>
                 <Dropdown.Divider />

--- a/client/src/ui/Sidebar.jsx
+++ b/client/src/ui/Sidebar.jsx
@@ -1,7 +1,7 @@
 import { cn } from './utils';
 
 const links = [
-  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/admin', label: 'Dashboard' },
   { href: '/cms', label: 'CMS' },
   { href: '/tryit', label: 'Editor' },
   { href: '/visualizer', label: 'Visualizer' },


### PR DESCRIPTION
## Summary
- add `/admin` route for `AdminDashboard` under admin-only protection
- update sidebar and header links to target `/admin`
- align profile-related prompts and tables with new admin path

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c62e9f60f0832d94b142f7f2949133