### PR TITLE
feat: add admin data listing routes

### DIFF
--- a/api/controllers/admin.controller.js
+++ b/api/controllers/admin.controller.js
@@ -1,0 +1,150 @@
+import Post from '../models/post.model.js';
+import Tutorial from '../models/tutorial.model.js';
+import Quiz from '../models/quiz.model.js';
+import Comment from '../models/comment.model.js';
+import User from '../models/user.model.js';
+
+// List all posts
+export const getAllPosts = async (req, res, next) => {
+  try {
+    const startIndex = parseInt(req.query.startIndex) || 0;
+    const limit = parseInt(req.query.limit) || 9;
+    const sortDirection = req.query.order === 'asc' ? 1 : -1;
+    const sortBy = req.query.sort || 'updatedAt';
+    let sortOptions = {};
+    if (sortBy === 'claps') {
+      sortOptions.claps = -1;
+    } else {
+      sortOptions[sortBy] = sortDirection;
+    }
+    const posts = await Post.find()
+      .sort(sortOptions)
+      .skip(startIndex)
+      .limit(limit);
+    const totalPosts = await Post.countDocuments();
+    const now = new Date();
+    const oneMonthAgo = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      now.getDate()
+    );
+    const lastMonthPosts = await Post.countDocuments({
+      createdAt: { $gte: oneMonthAgo },
+    });
+    res.status(200).json({ posts, totalPosts, lastMonthPosts });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// List all tutorials
+export const getAllTutorials = async (req, res, next) => {
+  try {
+    const startIndex = parseInt(req.query.startIndex) || 0;
+    const limit = parseInt(req.query.limit) || 9;
+    const sortDirection = req.query.order === 'asc' ? 1 : -1;
+    const tutorials = await Tutorial.find()
+      .sort({ updatedAt: sortDirection })
+      .skip(startIndex)
+      .limit(limit);
+    const totalTutorials = await Tutorial.countDocuments();
+    const now = new Date();
+    const oneMonthAgo = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      now.getDate()
+    );
+    const lastMonthTutorials = await Tutorial.countDocuments({
+      createdAt: { $gte: oneMonthAgo },
+    });
+    res.status(200).json({
+      tutorials,
+      totalTutorials,
+      lastMonthTutorials,
+    });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// List all quizzes
+export const getAllQuizzes = async (req, res, next) => {
+  try {
+    const startIndex = parseInt(req.query.startIndex) || 0;
+    const limit = parseInt(req.query.limit) || 9;
+    const sortDirection = req.query.sort === 'asc' ? 1 : -1;
+    const quizzes = await Quiz.find()
+      .sort({ updatedAt: sortDirection })
+      .skip(startIndex)
+      .limit(limit)
+      .populate('createdBy', 'username profilePicture')
+      .populate('relatedTutorials', 'title slug');
+    const totalQuizzes = await Quiz.countDocuments();
+    const now = new Date();
+    const oneMonthAgo = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      now.getDate()
+    );
+    const lastMonthQuizzes = await Quiz.countDocuments({
+      createdAt: { $gte: oneMonthAgo },
+    });
+    res.status(200).json({ quizzes, totalQuizzes, lastMonthQuizzes });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// List all comments
+export const getAllComments = async (req, res, next) => {
+  try {
+    const startIndex = parseInt(req.query.startIndex) || 0;
+    const limit = parseInt(req.query.limit) || 9;
+    const sortDirection = req.query.sort === 'desc' ? -1 : 1;
+    const comments = await Comment.find()
+      .sort({ createdAt: sortDirection })
+      .skip(startIndex)
+      .limit(limit);
+    const totalComments = await Comment.countDocuments();
+    const now = new Date();
+    const oneMonthAgo = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      now.getDate()
+    );
+    const lastMonthComments = await Comment.countDocuments({
+      createdAt: { $gte: oneMonthAgo },
+    });
+    res.status(200).json({ comments, totalComments, lastMonthComments });
+  } catch (error) {
+    next(error);
+  }
+};
+
+// List all users
+export const getAllUsers = async (req, res, next) => {
+  try {
+    const startIndex = parseInt(req.query.startIndex) || 0;
+    const limit = parseInt(req.query.limit) || 9;
+    const sortDirection = req.query.sort === 'asc' ? 1 : -1;
+    const users = await User.find()
+      .sort({ createdAt: sortDirection })
+      .skip(startIndex)
+      .limit(limit)
+      .select('-password');
+    const totalUsers = await User.countDocuments();
+    const now = new Date();
+    const oneMonthAgo = new Date(
+      now.getFullYear(),
+      now.getMonth() - 1,
+      now.getDate()
+    );
+    const lastMonthUsers = await User.countDocuments({
+      createdAt: { $gte: oneMonthAgo },
+    });
+    res.status(200).json({ users, totalUsers, lastMonthUsers });
+  } catch (error) {
+    next(error);
+  }
+};
+

--- a/api/index.js
+++ b/api/index.js
@@ -8,6 +8,7 @@ import postRoutes from './routes/post.route.js';
 import commentRoutes from './routes/comment.route.js';
 import tutorialRoutes from './routes/tutorial.route.js';
 import quizRoutes from './routes/quiz.route.js';
+import adminRoutes from './routes/admin.route.js';
 import codeSnippetRoutes from './routes/codeSnippet.route.js';
 import cppRoutes from './routes/cpp.route.js';
 import pythonRoutes from './routes/python.route.js';
@@ -17,6 +18,8 @@ import cookieParser from 'cookie-parser';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import cors from 'cors';
+import { verifyToken } from './utils/verifyUser.js';
+import { verifyAdmin } from './utils/verifyAdmin.js';
 
 dotenv.config();
 
@@ -63,6 +66,7 @@ app.use('/api/auth', authRoutes);
 app.use('/api/post', postRoutes);
 app.use('/api/comment', commentRoutes);
 app.use('/api/tutorial', tutorialRoutes);
+app.use('/api/admin', verifyToken, verifyAdmin, adminRoutes);
 app.use('/api/code-snippet', codeSnippetRoutes);
 app.use('/api', quizRoutes);
 app.use('/api/code', cppRoutes); // NEW: Use the new C++ route

--- a/api/routes/admin.route.js
+++ b/api/routes/admin.route.js
@@ -1,0 +1,18 @@
+import express from 'express';
+import {
+  getAllPosts,
+  getAllTutorials,
+  getAllQuizzes,
+  getAllComments,
+  getAllUsers,
+} from '../controllers/admin.controller.js';
+
+const router = express.Router();
+
+router.get('/posts', getAllPosts);
+router.get('/tutorials', getAllTutorials);
+router.get('/quizzes', getAllQuizzes);
+router.get('/comments', getAllComments);
+router.get('/users', getAllUsers);
+
+export default router;


### PR DESCRIPTION
## Summary
- add controller with handlers for admin data listing
- expose admin endpoints for posts, tutorials, quizzes, comments, and users
- wire admin routes with token and admin verification

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c633ce777c832d98ad98fd99266351