### PR TITLE
feat: add CMS page

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -26,6 +26,7 @@ const SignIn = lazy(() => import('./pages/SignIn.jsx'));
 const SignUp = lazy(() => import('./pages/SignUp.jsx'));
 const TryItPage = lazy(() => import('./pages/TryItPage.jsx'));
 const CodeVisualizer = lazy(() => import('./pages/CodeVisualizer.jsx'));
+const Cms = lazy(() => import('./pages/Cms.jsx'));
 const NotFound = lazy(() => import('./pages/NotFound.jsx'));
 const AccessDenied = lazy(() => import('./pages/AccessDenied.jsx'));
 
@@ -48,6 +49,7 @@ export default function App() {
                     <Route path="/quizzes/:quizSlug" element={<SingleQuizPage />} />
                     <Route path="/tryit" element={<TryItPage />} />
                     <Route path="/visualizer" element={<CodeVisualizer />} />
+                    <Route path="/cms" element={<Cms />} />
                     <Route path="/access-denied" element={<AccessDenied />} />
 
                     <Route element={<PrivateRoute />}>

--- a/client/src/pages/Cms.jsx
+++ b/client/src/pages/Cms.jsx
@@ -1,0 +1,14 @@
+import EmptyState from '../ui/EmptyState.jsx';
+import Button from '../ui/Button.jsx';
+
+export default function Cms() {
+  return (
+    <div className="p-4">
+      <EmptyState
+        title="Content Management"
+        description="Manage your site's content from here."
+        action={<Button>Get Started</Button>}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- scaffold basic CMS page with placeholder UI
- register CMS route and lazy-loaded component

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c6d104ce64832d892614b78f6f1582