### PR TITLE
Add CMS creation links

### DIFF
--- a/client/src/pages/Cms.jsx
+++ b/client/src/pages/Cms.jsx
@@ -1,14 +1,18 @@
-import EmptyState from '../ui/EmptyState.jsx';
+import { Link } from 'react-router-dom';
 import Button from '../ui/Button.jsx';
 
 export default function Cms() {
   return (
-    <div className="p-4">
-      <EmptyState
-        title="Content Management"
-        description="Manage your site's content from here."
-        action={<Button>Get Started</Button>}
-      />
+    <div className="p-4 flex flex-col gap-4">
+      <Link to="/create-post">
+        <Button>New Post</Button>
+      </Link>
+      <Link to="/create-tutorial">
+        <Button>New Tutorial</Button>
+      </Link>
+      <Link to="/create-quiz">
+        <Button>New Quiz</Button>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace CMS empty state with buttons linking to creation routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6d4684a9c832d8b0e511c44b0e646