### PR TITLE
Render profile tab in admin dashboard

### DIFF
--- a/client/src/pages/AdminDashboard.jsx
+++ b/client/src/pages/AdminDashboard.jsx
@@ -6,6 +6,7 @@ import DashUsers from '../components/DashUsers.jsx';
 import DashTutorials from '../components/DashTutorials.jsx';
 import DashQuizzes from '../components/DashQuizzes.jsx';
 import DashComments from '../components/DashComments.jsx';
+import DashProfile from '../components/DashProfile.jsx';
 import Dashboard from './Dashboard.jsx';
 
 export default function AdminDashboard() {
@@ -32,6 +33,8 @@ export default function AdminDashboard() {
         return <DashQuizzes />;
       case 'comments':
         return <DashComments />;
+      case 'profile':
+        return <DashProfile />;
       case 'dash':
       default:
         return <Dashboard />;


### PR DESCRIPTION
## Summary
- import DashProfile component in AdminDashboard
- render DashProfile when the `profile` tab is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68c6d6a22e44832d93ed1e70ae70257d