### PR TITLE
Add profile page and route

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -24,6 +24,7 @@ const PostListPage = lazy(() => import('./pages/PostListPage.jsx'));
 const Search = lazy(() => import('./pages/Search.jsx'));
 const SignIn = lazy(() => import('./pages/SignIn.jsx'));
 const SignUp = lazy(() => import('./pages/SignUp.jsx'));
+const Profile = lazy(() => import('./pages/Profile.jsx'));
 const TryItPage = lazy(() => import('./pages/TryItPage.jsx'));
 const CodeVisualizer = lazy(() => import('./pages/CodeVisualizer.jsx'));
 const Cms = lazy(() => import('./pages/Cms.jsx'));
@@ -53,6 +54,7 @@ export default function App() {
                     <Route path="/access-denied" element={<AccessDenied />} />
 
                     <Route element={<PrivateRoute />}>
+                        <Route path="/profile" element={<Profile />} />
                         <Route element={<OnlyAdminPrivateRoute />}>
                             <Route path="/admin" element={<AdminDashboard />} />
                             <Route path="/create-post" element={<CreatePost />} />

--- a/client/src/components/layout/Sidebar.jsx
+++ b/client/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { LayoutDashboard, FileText, FlaskConical, ListChecks, Settings, ShieldCheck, BookOpenText } from 'lucide-react';
+import { LayoutDashboard, FileText, FlaskConical, ListChecks, Settings, ShieldCheck, BookOpenText, User } from 'lucide-react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 
@@ -8,6 +8,7 @@ const items = [
   { icon: BookOpenText, label: 'CMS', href: '/cms' },
   { icon: FlaskConical, label: 'Playground', href: '/tryit' },
   { icon: ListChecks, label: 'Quizzes', href: '/quizzes' },
+  { icon: User, label: 'Profile', href: '/profile' },
   { icon: ShieldCheck, label: 'Admin', href: '/admin' },
   { icon: Settings, label: 'Settings', href: '/settings' },
 ];

--- a/client/src/pages/Profile.jsx
+++ b/client/src/pages/Profile.jsx
@@ -1,0 +1,4 @@
+import DashProfile from '../components/DashProfile.jsx';
+export default function Profile() {
+  return <DashProfile />;
+}


### PR DESCRIPTION
## Summary
- add profile page component wrapping DashProfile
- register /profile route and lazy-loading
- expose profile link in sidebar

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68c6da83a664832db02086fa27972b1f