### PR TITLE
Fix static asset path

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -73,10 +73,10 @@ app.use('/api/code', cppRoutes); // NEW: Use the new C++ route
 app.use('/api/code', pythonRoutes); // NEW: Use the new Python route
 app.use('/api', executeRoutes); // NEW: Unified execution route for JS/Python
 
-app.use(express.static(path.join(__dirname, '/client/dist')));
+app.use(express.static(path.join(__dirname, '../client/dist')));
 
 app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, 'client', 'dist', 'index.html'));
+    res.sendFile(path.join(__dirname, '../client/dist', 'index.html'));
 });
 
 app.use((err, req, res, next) => {


### PR DESCRIPTION
## Summary
- serve built client from project root

## Testing
- `npm test`
- `npm run build --prefix client`
- `JWT_SECRET=dummytoken node api/index.js` then `curl -i http://localhost:3000` and `curl -i http://localhost:3000/assets/About-fdwHXzFH.js`


------
https://chatgpt.com/codex/tasks/task_b_68c6e270d58c832d9a84a58555bcbdf2