### PR TITLE
chore: remove duplicate execution route

### DIFF
--- a/api/routes/route.js
+++ b/api/routes/route.js
@@ -1,8 +1,0 @@
-import express from 'express';
-import { executeCode } from '../controllers/execution.controller.js';
-
-const router = express.Router();
-
-router.post('/execute', executeCode);
-
-export default router;


### PR DESCRIPTION
## Summary
- remove redundant execution route file
- keep execute.route.js as sole execution endpoint

## Testing
- `npm test` *(fails: npm command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c6e5b59e74832d9e93ad9fdae184de