### PR TITLE
feat: add global font and unify typography

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,8 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
     <title>Scientist Shield</title>
   </head>
   <body class="antialiased">

--- a/client/src/components/DashProfile.jsx
+++ b/client/src/components/DashProfile.jsx
@@ -149,16 +149,17 @@ export default function DashProfile() {
           >
             {isUploading && (
                 <div className='absolute inset-0 z-10 flex flex-col justify-center items-center'>
-                  <CircularProgressbar
-                      value={progress || 0}
-                      text={`${progress}%`}
-                      strokeWidth={5}
-                      styles={{
-                        root: { width: '100%', height: '100%' },
-                        path: { stroke: `rgba(62, 152, 199, ${progress / 100})` },
-                        text: { fill: '#f8fafc', fontSize: '24px' },
-                      }}
-                  />
+                    <CircularProgressbar
+                        value={progress || 0}
+                        text={`${progress}%`}
+                        strokeWidth={5}
+                        className="text-base"
+                        styles={{
+                          root: { width: '100%', height: '100%' },
+                          path: { stroke: `rgba(62, 152, 199, ${progress / 100})` },
+                          text: { fill: '#f8fafc' },
+                        }}
+                    />
                   <Button size="xs" className="absolute bottom-2" color="light" onClick={cancelUpload}>Cancel</Button>
                 </div>
             )}

--- a/client/src/components/ExecutionVisualizer.jsx
+++ b/client/src/components/ExecutionVisualizer.jsx
@@ -131,8 +131,7 @@ export default function ExecutionVisualizer() {
             .attr('text-anchor', 'middle')
             .attr('dy', '0.35em')
             .attr('fill', 'white')
-            .style('font-family', 'monospace')
-            .style('font-size', '12px')
+            .attr('class', 'font-mono text-xs')
             .text(d => d.label);
 
         // Show the full source line on hover for better context

--- a/client/src/pages/CreateTutorial.jsx
+++ b/client/src/pages/CreateTutorial.jsx
@@ -657,11 +657,17 @@ export default function CreateTutorial() {
                                     />
                                     {isUploading && (
                                         <div className='w-20 h-20 self-center'>
-                                            <CircularProgressbar value={uploadProgress} text={`${uploadProgress}%`} strokeWidth={10} styles={{
-                                                root: { width: '100%', height: '100%' },
-                                                path: { stroke: `rgba(62, 152, 199, ${uploadProgress / 100})` },
-                                                text: { fill: '#3b82f6', fontSize: '16px' },
-                                            }} />
+                                          <CircularProgressbar
+                                              value={uploadProgress}
+                                              text={`${uploadProgress}%`}
+                                              strokeWidth={10}
+                                              className="text-base"
+                                              styles={{
+                                                  root: { width: '100%', height: '100%' },
+                                                  path: { stroke: `rgba(62, 152, 199, ${uploadProgress / 100})` },
+                                                  text: { fill: '#3b82f6' },
+                                              }}
+                                          />
                                         </div>
                                     )}
                                 </div>

--- a/client/src/styles/globals.css
+++ b/client/src/styles/globals.css
@@ -5,6 +5,9 @@
 @import './theme.css';
 
 body {
+  font-family: 'Inter', sans-serif;
+  font-size: 16px;
+  line-height: 1.5;
   background-color: hsl(var(--bg));
   color: hsl(var(--text));
 }

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -8,6 +8,10 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', ...defaultTheme.fontFamily.sans],
+        inter: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+      spacing: {
+        18: '4.5rem',
       },
       boxShadow: {
         soft: '0 1px 2px 0 rgba(0,0,0,0.05)',


### PR DESCRIPTION
## Summary
- load Inter from Google Fonts globally
- set base typography styles and extend Tailwind configuration
- replace hard coded font sizes with Tailwind classes

## Testing
- `npm test`
- `npm run lint` *(fails: Fast refresh warnings, unused vars, and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c764574368832db2fbb48a22036ca5